### PR TITLE
v6web: mobile-friendly scrolling

### DIFF
--- a/v6web/index.html
+++ b/v6web/index.html
@@ -31,7 +31,8 @@ window.onload = function() {
     font-family: 'Minion 3', 'Minion Pro', serif;
   }
   #input {
-    outline: none;
+    opacity: 0;
+    appearance: none;
   }
   #controls {
   }
@@ -65,17 +66,14 @@ window.onload = function() {
     font-family: 'Go83 Mono', monospace;
     font-size: 100%;
   }
-  #input {
-    position: absolute;
-    left: -1000px;
-    top: 0px;
+  #bottom {
+    margin-left: -1em;
   }
   </style>
 </head>
 <body>
 <h1>Research Unix Sixth Edition (WASM)</h1>
 
-<input type="text" id="input"></input>
 <pre><div id="ttyall"><div id="tty0"><b>tty0</b>
 </div><div id="tty1"><b>tty1</b>
 </div><div id="tty2"><b>tty2</b>
@@ -87,7 +85,7 @@ window.onload = function() {
 </div><div id="tty8"><b>tty8</b>
 </div></div>
 
-<div id="bottom"></div></div></pre>
+</div></pre>
 <button id="btty0">tty0</button>
 <button id="btty1">tty1</button>
 <button id="btty2">tty2</button>
@@ -97,7 +95,7 @@ window.onload = function() {
 <button id="btty6">tty6</button>
 <button id="btty7">tty7</button>-->
 <button id="btty8">tty8</button>
-
+<div id="bottom"><input type="text" id="input"></div>
 <div id="about">
 <p>
 This web page runs a Go port of <br>
@@ -123,8 +121,7 @@ so long computations block the browser UI.
 </p>
 
 <p>On mobile devices, clicking a tty button<br>
-should bring up the keyboard, <br>
-but scrolling to the output point seems broken. <br>
+should bring up the keyboard.<br>
 <a href="https://github.com/rsc/unix/">Patches welcome.</a>
 </p>
 

--- a/v6web/main.go
+++ b/v6web/main.go
@@ -96,7 +96,12 @@ func main() {
 				button.Get("style").Set("color", "black")
 			}
 		}
-		input.Call("focus")
+
+		input.Call("focus", map[string]any{"preventScroll": true})
+		js.Global().Call("setTimeout", js.FuncOf(func(this js.Value, args []js.Value) any {
+			bottom.Call("scrollIntoView", map[string]any{"block": "end", "inline": "start"})
+			return nil
+		}), 200)
 	}
 	setTTY(8)
 	for _, i := range ttys {


### PR DESCRIPTION
Hello, love this project. It's super cool!

Here's a minimal fix for the tty scrolling issue on mobile. It's not perfect but it should make it useable for mobile browsers.

- Hidden input changes:
  - Make #input fully transparent instead of offscreen, fixes mobile browsers scrolling left
  - Move `#input` inside of `#bottom` so default focus behavior gets us close to where we want to be
- Scrolling changes:
  - When focusing input, use `preventScroll: true`, this prevents iOS Safari from zooming in
  - During tty switch scroll after a 200ms timeout, which gives the onscreen keyboard time to pop up. The magic number is gross and I tried a bunch of alternatives but this is the only approach I could get to work consistently 🥲.
  - Give #bottom a bit of negative left margin to that scrolling to it will leave some margin space on screen
  - Move #bottom to after the tty selection buttons; this keeps them in view and gives mobile browsers a bit of a vertical space buffer so that even if scrolling overshoots the y axis (seems to happen rarely, you can see it at the end of the video below) it will still keep the terminal cursor in view.

Video from iOS Safari:

https://github.com/rsc/unix/assets/131059/542083d3-8e33-4093-b073-3ef76d573830



