### PR TITLE
v6web: fix input listening on Android

### DIFF
--- a/v6web/main.go
+++ b/v6web/main.go
@@ -153,7 +153,18 @@ func main() {
 		return nil
 	})
 
+	change := js.FuncOf(func(this js.Value, args []js.Value) any {
+		v := input.Get("value").String()
+		for _, b := range []byte(v) {
+			sys.TTY[curtty].WriteByte(b)
+			wakeup()
+		}
+		input.Set("value", "")
+		return nil
+	})
+
 	input.Call("addEventListener", "keydown", keydown)
+	input.Call("addEventListener", "input", change)
 	input.Call("focus")
 
 	fmt.Printf("started\n")


### PR DESCRIPTION
I saw a [comment](https://news.ycombinator.com/item?id=38057426) that input was wonky on Android so I made a little fix.

The problem seems to be that Android doesn't send the keydown event. This adds a listener for the 'input' event that checks the contents of the hidden input, sends the byte value, then clears it.
It shouldn't interfere with browsers that support the keydown handler because its preventDefault will stop 'input' from being fired.