### PR TITLE
pdp11: fix SXT to always clear V

### DIFF
--- a/pdp11/exec.go
+++ b/pdp11/exec.go
@@ -390,6 +390,7 @@ func xsxt(cpu *CPU) {
 	dst := uint16(int16(cpu.PS.N()<<15) >> 15)
 	cpu.writeW(dp, dst)
 	cpu.PS.setNZ(dst)
+	cpu.PS.SetV(false)
 }
 
 // double operand instructions

--- a/pdp11/testdata/exec_sxt.txt
+++ b/pdp11/testdata/exec_sxt.txt
@@ -186,3 +186,15 @@ sec
 mov #177777, r1
 sxt r1
 now r1=177777 nzvc=1001
+
+ccc
+sev
+sec
+now nzvc=0011
+sxt r1
+now nzvc=0101
+
+scc
+now nzvc=1111
+sxt r1
+now r1=177777 nzvc=1001


### PR DESCRIPTION
SXT should unconditionally clear the overflow flag.